### PR TITLE
Options for context and fail when unused fixtures are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,40 @@ Running the tests is required to accurately record which fixtures are used, as p
 $ pip install pytest-unused-fixtures
 ```
 
+## Options
+
+| Option Name                           | Type             | Description                                                    |
+|---------------------------------------|------------------|----------------------------------------------------------------|
+| `--unused-fixtures`                   | switch           | Enable plugin                                                  |
+| `--unused-fixtures-ignore-path`       | string*          | Ignore paths for consideration of unused fixtures              |
+| `--unused-fixtures-context`           | array\<string\>  | Only consider fixtures missing if defined in these directories |
+| `--unused-fixtures-fail-when-present` | switch           | Fail pytest session if unused fixtures are present             |
+
+
 ## Usage
 
 After installing the package, the plugin is enabled by adding the switch `--unused-fixtures`.
 
 Paths of fixtures can be ignored with one or multiple `--unused-fixtures-ignore-path` arguments. For example `--unused-fixtures-ignore-path=venv` will ignore all fixtures defined in the `venv` folder.
+
+Alternatively, you can limit the scope in which the plugin looks for unused fixtures to a specific directory or directories. For example:
+
+**Limit scope to one directory**
+This example will only display unused fixtures that were defined in the `tests` folder
+```shell
+pytest tests --unused-fixtures --unused-fixtures-context tests
+```
+
+**Limit scope to multiple directories**
+This example will only display unused fixtures that were defined in the `directory1` and `directory2/sub-directory` folders
+```shell
+pytest tests --unused-fixtures --unused-fixtures-context directory1 directory2/sub-directory
+```
+
+**Fail test session**
+By default, when you use the `--unused-fixtures` switch, the plugin will exit with the same exit code pytest
+would have used if running without the plugin. Add the switch `--unused-fixtures-fail-when-present` and the
+pytest session will return a non-zero exit code if there are unused fixtures.
 
 ### Ignoring specific fixtures from report
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-unused-fixtures"
-version = "0.1.5"
+version = "0.2.0"
 description = "A pytest plugin to list unused fixtures after a test run."
 authors = ["Mikuláš Poul <mikulaspoul@gmail.com>"]
 license = "MIT"

--- a/pytest_unused_fixtures/options.py
+++ b/pytest_unused_fixtures/options.py
@@ -18,6 +18,12 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager) -> NoRe
         action="append",
         help="Ignore fixtures in PATHs from unused fixtures report.",
     )
+    group.addoption(
+        "--unused-fixtures-fail-when-present",
+        action="store_true",
+        default=False,
+        help="Exit the pytest session with a failure code if unused fixtures are found",
+    )
 
 
 def pytest_configure(config: Config) -> NoReturn:

--- a/pytest_unused_fixtures/options.py
+++ b/pytest_unused_fixtures/options.py
@@ -24,6 +24,14 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager) -> NoRe
         default=False,
         help="Exit the pytest session with a failure code if unused fixtures are found",
     )
+    group.addoption(
+        "--unused-fixtures-context",
+        metavar="PATH",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Limit the scope of which to look for unused fixtures to these directories",
+    )
 
 
 def pytest_configure(config: Config) -> NoReturn:
@@ -40,4 +48,6 @@ def pytest_configure(config: Config) -> NoReturn:
 
         plugin = PytestUnusedFixturesPluginXdist
 
-    pluginmanager.register(plugin(config.getoption("--unused-fixtures-ignore-path")))
+    paths_ignore = config.getoption("--unused-fixtures-ignore-path")
+    unused_fixture_context = config.getoption("--unused-fixtures-context")
+    pluginmanager.register(plugin(paths_ignore, unused_fixture_context))

--- a/pytest_unused_fixtures/plugin.py
+++ b/pytest_unused_fixtures/plugin.py
@@ -40,11 +40,12 @@ class FixtureInfo:
 
 
 class PytestUnusedFixturesPlugin:
-    def __init__(self, ignore_paths: list[str | Path] | None = None):
+    def __init__(self, ignore_paths: list[str | Path] | None = None, context: list[str | Path] | None = None):
         self.ignore_paths: list[Path] = [Path(x).resolve() for x in (ignore_paths or [])]
         self.used_fixtures: set[FixtureInfo] = set()
         self.available_fixtures: None | set[FixtureInfo] = None
         self.curdir = Path().cwd()
+        self.context = context or []
         self._shouldfail = False
 
     def get_fixture_info(self, fixturedef: FixtureDef) -> FixtureInfo:
@@ -124,6 +125,11 @@ class PytestUnusedFixturesPlugin:
         non_ignored_unused_fixtures = set()
         for fixture in unused_fixtures:
             if any(fixture.location_path.is_relative_to(x) or fixture.location_path == x for x in self.ignore_paths):
+                continue
+            fixtures_in_context = [
+                fixture.location_path.is_relative_to(x) for x in [Path(i).resolve() for i in self.context]
+            ]
+            if fixtures_in_context and not any(fixtures_in_context):
                 continue
             non_ignored_unused_fixtures.add(fixture)
 

--- a/pytest_unused_fixtures/xdist.py
+++ b/pytest_unused_fixtures/xdist.py
@@ -21,6 +21,8 @@ class PytestUnusedFixturesPluginXdist(PytestUnusedFixturesPlugin):
             workeroutput[_WORKEROUTPUT_KEY_AVAILABLE] = list(map(asdict, self.available_fixtures))
             workeroutput[_WORKEROUTPUT_KEY_USED] = list(map(asdict, self.used_fixtures))
 
+        super().pytest_sessionfinish(session, exitstatus)
+
     def pytest_testnodedown(self, node: WorkerController, error: Any | None) -> NoReturn:
         if (workeroutput := getattr(node, "workeroutput", None)) is not None:
             # add used & available fixtures from nodes

--- a/tests/test_base_class.py
+++ b/tests/test_base_class.py
@@ -51,3 +51,25 @@ def test_default(pytester, sample_testfile):
         ],
         consecutive=True,
     )
+
+
+def test_option_context(pytester, sample_testfile):
+    """
+    test the option `--unused-fixtures-context`.
+    """
+    result = pytester.runpytest("--unused-fixtures", "--unused-fixtures-context", Path(__file__).parent)
+    result.assert_outcomes(passed=2)
+    result.stdout.no_fnmatch_line("*UNUSED FIXTURES*")
+
+
+def test_fail_when_present(pytester, sample_testfile):
+    result = pytester.runpytest("--unused-fixtures", "--unused-fixtures-fail-when-present")
+    result.stdout.fnmatch_lines(["*ERROR: Unused fixtures failure: total of 1 unused fixtures*"])
+    result.stdout.fnmatch_lines(
+        [
+            "*UNUSED FIXTURES*",
+            "*fixtures defined from test_fail_when_present*",
+            "*fixture_c -- test_fail_when_present.py:12*",
+        ],
+    )
+    assert result.ret == pytest.ExitCode.TESTS_FAILED


### PR DESCRIPTION
@mikicz - Thanks for creating this plugin, I find it's pretty useful for keeping things clean when refactoring or using in large codebases.

In this PR I have attempted to add a couple of extra options to extend it a bit. 

## `--unused-fixtures-fail-when-present`
A boolean option that, when set to true, will set the pytest exit code to failure when there are unused fixtures present in the test session. I think this could be useful for CICD scenarios when this plugin is used

## `--unused-fixtures-context`
Pass one or more directories that should act as the context for missing fixtures i.e. only consider fixtures missing if they are defined in any of the context directories. This makes it easy to limit the scope of missing fixtures to just the `tests` directory in the current repo

## baseid check
I added the `baseid` check to `pytest_collection_finish` as the tests were failing when I ran them locally before making any changes. The logs reported there were unused fixtures in the `_pytest` module (even with my virtual environment named venv). Example log output:

```
------------------------------------------------------------------ Captured stdout call -------------------------------------------------------------------
============================= test session starts =============================
platform win32 -- Python 3.11.9, pytest-8.3.3, pluggy-1.5.0
rootdir: XXX\pytest-unused-fixtures
configfile: pyproject.toml
plugins: unused-fixtures-0.1.5, xdist-3.6.1
collected 1 item

..\..\..\..\..\..\GitHub\pytest-unused-fixtures\test_default.py .        [100%]

=============================== UNUSED FIXTURES ===============================
cache -- C:555
capsysbinary -- C:1005
capfd -- C:1033
capfdbinary -- C:1061
capsys -- C:977
doctest_namespace [session scope] -- C:740
pytestconfig [session scope] -- C:1344
record_property -- C:279
record_xml_attribute -- C:302
record_testsuite_property [session scope] -- C:340
tmpdir_factory [session scope] -- C:297
tmpdir -- C:304
caplog -- C:597
monkeypatch -- C:30
recwarn -- C:34
tmp_path_factory [session scope] -- C:241
tmp_path -- C:256
--------------------- fixtures defined from test_default ----------------------
fixture_c -- test_default.py:14
--------------------- fixtures defined from xdist.plugin ----------------------
worker_id [session scope] -- C:354
testrun_uid [session scope] -- C:363
============================== 1 passed in 1.04s ==============================
================================================================= short test summary info =================================================================
FAILED tests/test_base_class.py::test_default - Failed: nomatch: '*UNUSED FIXTURES*'
FAILED tests/test_ignore.py::test_default - Failed: nomatch: '*UNUSED FIXTURES*'
==================================================================== 2 failed in 2.86s ====================================================================
```

I'm not 100% sure this is the right thing to do as I'm not an expert on the pytest internals. There's some info in the docs [here](https://docs.pytest.org/en/stable/_modules/_pytest/fixtures.html#FixtureDef:~:text=%23%20The%20%22base%22%20node,baseid%20or%20%22%22) 


## Tests
I haven't added any tests for new functionality yet, I wanted to get your feedback on the proposed changes first. Happy to add these if you are happy with the proposed features 


Let me know your thoughts 