### PR TITLE
Allow decorating fixtures with `ignore_unused_fixture`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ def ignored_fixture():
     pass
 ```
 
+Alternatively, if you prefer module imports:
+
+```python
+import pytest
+import pytest_unused_fixtures
+
+@pytest.fixture
+@pytest_unused_fixtures.ignore
+def ignored_fixture():
+    pass
+```
+
+
 ## Development
 
 [Poetry](https://python-poetry.org/) (dependencies) and [pre-commit](https://pre-commit.com/) (coding standards) are required for development. There are some tests, obviously written in [pytest](https://pytest.org/).

--- a/pytest_unused_fixtures/__init__.py
+++ b/pytest_unused_fixtures/__init__.py
@@ -1,4 +1,7 @@
-from .decorators import ignore_unused_fixture  # noqa: F401
-from .options import pytest_addoption, pytest_configure  # noqa: F401
+from .decorators import ignore_unused_fixture
+from .options import pytest_addoption as pytest_addoption
+from .options import pytest_configure as pytest_configure
 
 __version__ = "0.1.5"
+
+ignore = ignore_unused_fixture

--- a/pytest_unused_fixtures/decorators.py
+++ b/pytest_unused_fixtures/decorators.py
@@ -1,4 +1,21 @@
-def ignore_unused_fixture(func):
-    func.ignore_unused_fixture = True
+from __future__ import annotations
 
-    return func
+from typing import TYPE_CHECKING, TypeVar
+
+from .plugin import IGNORE_ATTR_NAME
+
+if TYPE_CHECKING:
+    from _pytest.fixtures import FixtureFunction, FixtureFunctionDefinition
+
+    Fixture = TypeVar("Fixture", bound=FixtureFunctionDefinition)
+
+
+def ignore_unused_fixture(func_or_fixture: FixtureFunction | Fixture) -> FixtureFunction | Fixture:
+    if hasattr(func_or_fixture, "_get_wrapped_function"):
+        func = func_or_fixture._get_wrapped_function()
+    else:
+        func = func_or_fixture
+
+    setattr(func, IGNORE_ATTR_NAME, True)
+
+    return func_or_fixture

--- a/pytest_unused_fixtures/decorators.py
+++ b/pytest_unused_fixtures/decorators.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from .plugin import IGNORE_ATTR_NAME
 
 if TYPE_CHECKING:
-    from _pytest.fixtures import FixtureFunction, FixtureFunctionDefinition
+    from _pytest.fixtures import FixtureFunctionDefinition
 
-    Fixture = TypeVar("Fixture", bound=FixtureFunctionDefinition)
+    FuncOrFixture = TypeVar("FuncOrFixture", Callable[..., Any], FixtureFunctionDefinition)
 
 
-def ignore_unused_fixture(func_or_fixture: FixtureFunction | Fixture) -> FixtureFunction | Fixture:
+def ignore_unused_fixture(func_or_fixture: FuncOrFixture) -> FuncOrFixture:
     if hasattr(func_or_fixture, "_get_wrapped_function"):
         func = func_or_fixture._get_wrapped_function()
     else:

--- a/pytest_unused_fixtures/plugin.py
+++ b/pytest_unused_fixtures/plugin.py
@@ -77,7 +77,6 @@ class PytestUnusedFixturesPlugin:
                 and getattr(fixturedef, "baseid", None) != ""
             )
         }
-        print(list(itertools.chain(*session._fixturemanager._arg2fixturedefs.values())))
 
     def _write_fixtures(self, config: Config, terminalreporter: TerminalReporter, fixtures: set[FixtureInfo]):
         verbose = config.getvalue("verbose")

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -19,6 +19,11 @@ def sample_testfile(pytester):
             def fixture_b(self):
                 return None
 
+            @ignore_unused_fixture
+            @pytest.fixture
+            def fixture_b_prime(self):
+                return None
+
             @pytest.fixture
             def fixture_c(self):
                 return None
@@ -44,7 +49,7 @@ def test_default(pytester, sample_testfile):
         [
             "*UNUSED FIXTURES*",
             "*fixtures defined from test_default*",
-            "*fixture_c -- test_default.py:14*",
+            "*fixture_c -- test_default.py:19*",
         ],
         consecutive=True,
     )


### PR DESCRIPTION
Hi, thanks for the nice plugin! 
I've noticed that while this works as expected:
```py
@pytest.fixture
@ignore_unused_fixture
def ignored_fixture():
    pass
```
this does not:
```py
@ignore_unused_fixture
@pytest.fixture
def ignored_fixture():
    pass
```

We're still decorating the original function as `FixtureDef`s do not retain any custom attributes set on `FixtureFunctionDefinition`s, but now we also attempt to unwrap it to support the second case.

I also gave the flag a more private name and took the liberty of adding an `ignore` shortcut for the decorator, purely for style.