### PR TITLE
Default `available_fixtures` to an empty set

### DIFF
--- a/pytest_unused_fixtures/plugin.py
+++ b/pytest_unused_fixtures/plugin.py
@@ -43,7 +43,7 @@ class PytestUnusedFixturesPlugin:
     def __init__(self, ignore_paths: list[str | Path] | None = None, context: list[str | Path] | None = None):
         self.ignore_paths: list[Path] = [Path(x).resolve() for x in (ignore_paths or [])]
         self.used_fixtures: set[FixtureInfo] = set()
-        self.available_fixtures: None | set[FixtureInfo] = None
+        self.available_fixtures: set[FixtureInfo] = set()
         self.curdir = Path().cwd()
         self.context = context or []
         self._shouldfail = False


### PR DESCRIPTION
A tiny but annoying one: since `pytest_terminal_summary` may run before `pytest_collection_finish` (e.g. on collection failure or a Ctrl-C), this may happen:

```py
INTERNALERROR>   File "<site>/pytest_unused_fixtures/plugin.py", line 126, in _get_unused_fixtures
INTERNALERROR>     unused_fixtures = self.available_fixtures - self.used_fixtures
INTERNALERROR>                       ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
INTERNALERROR> TypeError: unsupported operand type(s) for -: 'NoneType' and 'set'
```
and it also masks the original error.